### PR TITLE
chore(deps): update dependency babel-loader to ^7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.5.1",
-    "babel-loader": "^6.2.2",
+    "babel-loader": "^7.0.0",
     "eslint": "^3.0.1",
     "eslint-plugin-react": "^5.2.2",
     "node-libs-browser": "^1.0.0",


### PR DESCRIPTION
This Pull Request updates dependency [babel-loader](https://github.com/babel/babel-loader) from `^6.2.2` to `^7.0.0`



<details>
<summary>Release Notes</summary>

### [`v7.0.0`](https://github.com/babel/babel-loader/releases/v7.0.0)

##### 💥 Breaking Change
 * Drop support for node < 4
 * Drop support for webpack 1
##### 🚀 New Feature

* support babel-core@&#8203;7 (#&#8203;403) (Henry Zhu)
##### 🐛 Bug Fix

* Make sure .babelrc is a file, not a directory (#&#8203;427) (Hiroki Osame)
* Bump loader-utils and use getOptions (#&#8203;391) (Brian Ng)
* Ensure options are always an object (#&#8203;413) (Daniel Tschinder)
##### 📝 Documentation

 * Point changelog to releases (Daniel Tschinder)
 * Updated documentation to match webpack v2 changes. (#&#8203;438) (Jagadish Kasi)
 * Add note about webpack versions (Daniel Tschinder)
 * Update README.md for webpack 2 (#&#8203;402) (Sid Raval)
##### 🏠 Internal

 * chore(ci): get rid of node 0.10 (#&#8203;354) (Yuta Hiroto)
 * Use preset-env (#&#8203;406) (Daniel Tschinder)
 * Correctly run yarn commands (Daniel Tschinder)
 * Update ava to the latest version 🚀 (#&#8203;434) (greenkeeper[bot])
 * Update cross-env to the latest version 🚀 (#&#8203;431) (greenkeeper[bot])
 * chore(package): update babel-plugin-istanbul to version 4.0.0 (#&#8203;374) (greenkeeper[bot])
 * chore(package): update cross-env to version 3.1.4 (#&#8203;353) (greenkeeper[bot])
 * chore(package): update ava to version 0.18.0 (#&#8203;369) (greenkeeper[bot])
 * Use yarn (#&#8203;376) (Daniel Tschinder)
 * target node 4 in preset env (#&#8203;423) (Daniel Tschinder)
 * Add prettier (#&#8203;409) (Daniel Tschinder)
 * Use bash codecov (#&#8203;440) (Daniel Tschinder)

---

### [`v7.1.0`](https://github.com/babel/babel-loader/releases/v7.1.0)

##### 🚀 New Feature

* Update to support webpack 3 (#&#8203;471) (Joe Lencioni)
* look for babel options in package.json and .babelrc.js (babel 7) (#&#8203;465) (Thomas Sileghem)
* Watch configuration files. (#&#8203;460) (Evilebot Tnawi)
  You can now change the babel config while webpack watch or dev-server is running and webpack will correctly recompile all files with babel.
##### 🐛 Bug Fix

* Only base cache identifier on babel options from package.json (#&#8203;468) (Daniel Tschinder)
##### 📝 Documentation

 * Remove outdated examples. (Daniel Tschinder)
##### 🏠 Internal

 * update eslint-config-babel to version 7.0.0 (#&#8203;469) (greenkeeper[bot])
 * update lint-staged to version 4.0.0 (#&#8203;470) (greenkeeper[bot])
 * Add prettier eslint plugin (#&#8203;466) (Daniel Tschinder)
 * Add node 8 to test matrix (#&#8203;467) (Daniel Tschinder)
 * Upgrade find-cache-dir to 1.0 and cross-env to 5.0 (#&#8203;457) (Daniel Tschinder)

---

### [`v7.1.1`](https://github.com/babel/babel-loader/releases/v7.1.1)

##### 🐛 Bug Fix

* Do not read .babelrc for cache identifier when babelrc=false (#&#8203;483) (Russ Tyndall)
##### 📝 Documentation

 * Update README.md for webpack 3.x (#&#8203;476) (Pierre Neter)
##### 🏠 Internal

 * Update eslint to the latest version 🚀 (#&#8203;482) (greenkeeper[bot])
 * chore(package): update husky to version 0.14.0 (#&#8203;475) (greenkeeper[bot])

---

### [`v7.1.2`](https://github.com/babel/babel-loader/releases/v7.1.2)

##### 🐛 Bug Fix

* Add the message in BabelLoaderError's stack trace on node 8 (#&#8203;499)  (Stephen Jennings)
* Do not swallow errors in exists() and only call exists if option is string (#&#8203;495) (Nelo Mitranim)
##### 📝 Documentation

 * README: fix typo (#&#8203;498) (Piper Chester)
##### 🏠 Internal

 * Update ava to the latest version 🚀 (#&#8203;500)  (greenkeeper[bot])
 * Update ava to the latest version 🚀 (#&#8203;491)  (greenkeeper[bot])
 * Update ava to the latest version 🚀 (#&#8203;487)   (greenkeeper[bot])

---

### [`v7.1.3`](https://github.com/babel/babel-loader/releases/v7.1.3)

##### 🐛 Bug Fix

* Support webpack 4

---

### [`v7.1.4`](https://github.com/babel/babel-loader/releases/v7.1.4)

##### 🐛 Bug Fix

* Update code to read filename

---

</details>


<details>
<summary>Commits</summary>

#### v7.0.0
-   [`ed8711d`](https://github.com/babel/babel-loader/commit/ed8711d5275d9d59422d34252b5a99cf67869029) Add note about webpack versions
-   [`74ff2e6`](https://github.com/babel/babel-loader/commit/74ff2e6e7333a2ccad3cf6488f89f6e619e786f8) Updated documentation to match webpack v2 changes. (#&#8203;438)
-   [`5d248b5`](https://github.com/babel/babel-loader/commit/5d248b54c6b9cd88a6735e170041132f27719b7a) Update cross-env to the latest version 🚀 (#&#8203;431)
-   [`660922b`](https://github.com/babel/babel-loader/commit/660922b8a2973b42761e34b84b21aa41584b3a16) Update ava to the latest version 🚀 (#&#8203;434)
-   [`16522b6`](https://github.com/babel/babel-loader/commit/16522b67eba9e3ed67fb29dc0850da386065f8a3) yarn.lock
-   [`aa485e4`](https://github.com/babel/babel-loader/commit/aa485e42c44ebccc66c6be66b1900b7bdfc7b443) Use bash codecov (#&#8203;440)
-   [`dbec80d`](https://github.com/babel/babel-loader/commit/dbec80debaa9a7b9369b5febc4697e61c2d4f5f1) Make sure .babelrc is a file, not a directory (#&#8203;427)
-   [`2204871`](https://github.com/babel/babel-loader/commit/220487111ffd55f75063d6b7cf24c168b8035c58) Add prettier (#&#8203;409)
-   [`174cb10`](https://github.com/babel/babel-loader/commit/174cb10f87933ee49672b38af29dcd3153ea5975) Merge branch &#x27;7.0&#x27;
-   [`7307226`](https://github.com/babel/babel-loader/commit/7307226c26eb5e355a30f2447abfeaea526d5784) Point changelog to releases
-   [`1a76476`](https://github.com/babel/babel-loader/commit/1a76476752dc3dac970dbc1dd99a81db18a10411) 7.0.0
#### v7.1.0
-   [`37e63e3`](https://github.com/babel/babel-loader/commit/37e63e37cd46cf39949bfcfcf528b409afc6ca62) Upgrade find-cache-dir to 1.0 and cross-env to 5.0 (#&#8203;457)
-   [`de2d3f3`](https://github.com/babel/babel-loader/commit/de2d3f3ed5fb4943e2a39bb1214dd73c54590799) Upgrade dependencies
-   [`91f2658`](https://github.com/babel/babel-loader/commit/91f2658e039b036b02f04aff0bee719c839e99ce) Fixed: watch configuration files. (#&#8203;460)
-   [`8d96c1f`](https://github.com/babel/babel-loader/commit/8d96c1faa386d4393be3a0a181593af404ea10e1) Remove outdated examples.
-   [`d8b73c0`](https://github.com/babel/babel-loader/commit/d8b73c04fc0b984a3c80d9b918f45ddc95fe9893) fix(resolve-rc): look for babel in package.json and .babelrc.js (#&#8203;465)
-   [`4548169`](https://github.com/babel/babel-loader/commit/454816949212a15710a00633c26560430332a00f) Add node 8 to test matrix (#&#8203;467)
-   [`ea2eafa`](https://github.com/babel/babel-loader/commit/ea2eafac5ed2b83b8209d6238ac3d03309660896) Add prettier eslint plugin (#&#8203;466)
-   [`8544ffa`](https://github.com/babel/babel-loader/commit/8544ffad99ea877d984d505e7bd7ff2f5d762895) Only base cache identifier on babel options from pkg.json (#&#8203;468)
-   [`66784e4`](https://github.com/babel/babel-loader/commit/66784e42eaf0519f50e26b8de158acbd7c89e2d5) Update to webpack 3 (#&#8203;471)
-   [`ee40748`](https://github.com/babel/babel-loader/commit/ee407483cb2933e6c89e8c8a0e5fd4012009ac46) chore(package): update lint-staged to version 4.0.0 (#&#8203;470)
-   [`7986787`](https://github.com/babel/babel-loader/commit/79867879dc4975b614c6f653126f7b69bbff7eb8) chore(package): update eslint-config-babel to version 7.0.0 (#&#8203;469)
-   [`ea9b4d4`](https://github.com/babel/babel-loader/commit/ea9b4d407fda1e763dd324ca86343c68c0dd7f71) Update yarn.lock
-   [`d249119`](https://github.com/babel/babel-loader/commit/d24911948bec2b6be0d0ee1066589ea3cf400017) 7.1.0
#### v7.1.1
-   [`6063373`](https://github.com/babel/babel-loader/commit/6063373a5dc9c5d6ef1a06e094c4fd4c280a60cb) Update README.md for webpack 3.x (#&#8203;476)
-   [`c8924f3`](https://github.com/babel/babel-loader/commit/c8924f34a6f554b86fa0326fd2840574ea7110bc) chore(package): update husky to version 0.14.0 (#&#8203;475)
-   [`aefe583`](https://github.com/babel/babel-loader/commit/aefe583e0dc504e62cecc1a32dc7f70b46434915) Do not read .babelrc for cache identifier when babelrc&#x3D;false (#&#8203;483)
-   [`0815f48`](https://github.com/babel/babel-loader/commit/0815f486cb5ac728a901777a2c7a12311e53bc1f) Update eslint to the latest version 🚀 (#&#8203;482)
-   [`f3cacd9`](https://github.com/babel/babel-loader/commit/f3cacd9963aedc0e8f7dffaeb6ecec6df453c1cd) Update yarn.lock
-   [`5953fcf`](https://github.com/babel/babel-loader/commit/5953fcf2929536b10cdcc6ea37d81a877b1a5395) 7.1.1
#### v7.1.2
-   [`5e76bb7`](https://github.com/babel/babel-loader/commit/5e76bb78c30174bd968255081f80c793a23272ed) Update ava to the latest version 🚀 (#&#8203;487)
-   [`62ae6cc`](https://github.com/babel/babel-loader/commit/62ae6cc25453d78888ba93f8232b48fb3255bb11) Update ava to the latest version 🚀 (#&#8203;491)
-   [`f0bbb68`](https://github.com/babel/babel-loader/commit/f0bbb68ad484b5211926dafb57f25fd418d06dc4) Do not swallow errors in exists() and only call exists if option is string (#&#8203;495)
-   [`87b91f0`](https://github.com/babel/babel-loader/commit/87b91f09e58618e7912bd1e33f3221368da997c4) README: fix typo (#&#8203;498) [skip ci]
-   [`ffdf7f1`](https://github.com/babel/babel-loader/commit/ffdf7f103b6085a4e6f0e9d58719e1ec24e0e202) Update ava to the latest version 🚀 (#&#8203;500)
-   [`8558593`](https://github.com/babel/babel-loader/commit/85585938e713259525b86d99b30df9b85d052e97) Add the message in BabelLoaderError&#x27;s stack trace (#&#8203;499)
-   [`43543b7`](https://github.com/babel/babel-loader/commit/43543b7f20c6ec94442ece771ff5a7524d6dbb66) Update dependencies
-   [`1ca5c78`](https://github.com/babel/babel-loader/commit/1ca5c7856d2129a28d6ba031bd8a5759aa80b8eb) 7.1.2
#### v7.1.3
-   [`f753765`](https://github.com/babel/babel-loader/commit/f753765e7ddc97b79a363e06dc6ff8d825e41d94) Fix preset-env refs in README [skip ci]
-   [`e4f1aee`](https://github.com/babel/babel-loader/commit/e4f1aee1ee08a5e7d9ed53b84a68d2015845dc02) update readme versions [skip ci]
-   [`916affe`](https://github.com/babel/babel-loader/commit/916affe45bb7b7c9632cc3c21e5144bde499963f) Update lint-staged to the latest version 🚀 (#&#8203;536)
-   [`8b07d5d`](https://github.com/babel/babel-loader/commit/8b07d5d7b7e584a28d8c07bde23f342e675c7b9a) remove `@&#8203;next` since it&#x27;s not necessary on the scoped packages change [skip ci]
-   [`e6bb01e`](https://github.com/babel/babel-loader/commit/e6bb01e63969d0b459607164bb41c670d1abb734) Update ava to the latest version 🚀 (#&#8203;545)
-   [`7e95509`](https://github.com/babel/babel-loader/commit/7e95509500d28260a405f0970100cf44da561e4e) Update lint-staged to the latest version 🚀 (#&#8203;546)
-   [`b31d86f`](https://github.com/babel/babel-loader/commit/b31d86f1a189a0c7b810260f2fa89d146e6b749f) Fix preset-env and plugin-syntax-object-rest-spread refs. (#&#8203;549)
-   [`40552b6`](https://github.com/babel/babel-loader/commit/40552b60dfb1f070dd79d33de0bb799026592e20) Allow any version of webpack as a peerDependency (#&#8203;550)
-   [`8bd2521`](https://github.com/babel/babel-loader/commit/8bd2521fe15dd0e79ea71d138c21ea82cf82b80b) chore(package): update ava to version 0.25.0 (#&#8203;569)
-   [`638e433`](https://github.com/babel/babel-loader/commit/638e433da39c6638fd5f560f534ecec42c6c7768) Update readme.md (#&#8203;566)
-   [`23b3b97`](https://github.com/babel/babel-loader/commit/23b3b97b19dc5926a2e87ec4cc002b5c8aaf487c) fix compatibility with @&#8203;babel/core option check when inputSourceMap null (#&#8203;538)
-   [`7bf66bd`](https://github.com/babel/babel-loader/commit/7bf66bd710d7461c9288f539ceb5734c15ca4a86) docs(README): document babelrc option (#&#8203;442)
-   [`19caf69`](https://github.com/babel/babel-loader/commit/19caf69d71498362950c67f8608965def4dd7f2b) fix(babel): Update to latest babel version and fix babelrc behaviour (#&#8203;583)
-   [`552bdce`](https://github.com/babel/babel-loader/commit/552bdce759c40b138a335b18bf42afbd4f33ea42) refactor(src/Error): move `LoaderError` to separate file
-   [`be187cd`](https://github.com/babel/babel-loader/commit/be187cd0d45f5bacf29db0dd9d2094147f73d173) refactor(src/transform): move `transform` helper to separate file
-   [`27f44f8`](https://github.com/babel/babel-loader/commit/27f44f8a7bbf0079673ae50bb31cb84e22b764ae) style(src): modernize code
-   [`85bd8b7`](https://github.com/babel/babel-loader/commit/85bd8b7776db484d0d377a012049af6151b474ad) feat(src/cache): use async `transform` (`babel.transfrom`)
-   [`2109b8e`](https://github.com/babel/babel-loader/commit/2109b8ea4f92fbb3ed49bc725b5bcc55daffac14) feat(src/index): use async `transform` (`babel.transfrom`)
-   [`c1d2f83`](https://github.com/babel/babel-loader/commit/c1d2f83e3456eefbe6bc960631148a1c13223c38) chore(package): update `peerDependencies` &amp;&amp; `devDependencies`
-   [`537226d`](https://github.com/babel/babel-loader/commit/537226d9ad012e9c86a5577e215082a37ce1b3f8) Merge pull request #&#8203;584 from babel/michael-ciniawsky-feat
-   [`64dff0d`](https://github.com/babel/babel-loader/commit/64dff0db250983660f27d9ec89604970d7d79c38) Run tests with webpack 4 and fix them (#&#8203;585)
-   [`c436141`](https://github.com/babel/babel-loader/commit/c43614112dc0d1dda949d0ae9802a34152f7bca9) Update lint-staged
#### v7.1.4
-   [`b295162`](https://github.com/babel/babel-loader/commit/b29516266912fbc50120155fee00efb1b0a19f59) Format imports

</details>