### PR TITLE
chore(deps): update dependency eslint to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "babel-core": "^6.5.1",
     "babel-loader": "^6.2.2",
-    "eslint": "^3.0.1",
+    "eslint": "^4.0.0",
     "eslint-plugin-react": "^5.2.2",
     "node-libs-browser": "^1.0.0",
     "webpack": "^1.10.0"


### PR DESCRIPTION
This Pull Request updates dependency [eslint](https://github.com/eslint/eslint) from `^3.0.1` to `^4.0.0`



<details>
<summary>Release Notes</summary>

### [`v4.0.0`](https://github.com/eslint/eslint/releases/v4.0.0)

* 4aefb49 Chore: avoid using deprecated rules on ESLint codebase (#&#8203;8708) (Teddy Katz)
* 389feba Chore: upgrade deps. (#&#8203;8684) (薛定谔的猫)
* 3da7b5e Fix: Semi-Style only check for comments when tokens exist (fixes #&#8203;8696) (#&#8203;8697) (Reyad Attiyat)
* 3cfe9ee Fix: Add space between async and param on fix (fixes #&#8203;8682) (#&#8203;8693) (Reyad Attiyat)
* c702858 Chore: enable no-multiple-empty-lines on ESLint codebase (#&#8203;8694) (Teddy Katz)
* 34c4020 Update: Add support for parens on left side for-loops (fixes: #&#8203;8393) (#&#8203;8679) (Victor Hom)
* 735cd09 Docs: Correct the comment in an example for `no-mixed-requires` (#&#8203;8686) (Fangzhou Li)
* 026f048 Chore: remove dead code from prefer-const (#&#8203;8683) (Teddy Katz)

---

### [`v4.1.0`](https://github.com/eslint/eslint/releases/v4.1.0)

* e8f1362 Docs: Remove wrong descriptions in `padded-block` rule (#&#8203;8783) (Plusb Preco)
* 291a783 Update: `enforceForArrowConditionals` to `no-extra-parens` (fixes #&#8203;6196) (#&#8203;8439) (Evilebot Tnawi)
* a21dd32 New: Add `overrides`/`files` options for glob-based config (fixes #&#8203;3611) (#&#8203;8081) (Sylvan Mably)
* 879688c Update: Add ignoreComments option to no-trailing-spaces (#&#8203;8061) (Jake Roussel)
* b58ae2e Chore: Only instantiate fileEntryCache when cache flage set (perf) (#&#8203;8763) (Gyandeep Singh)
* 9851288 Update: fix indent errors on multiline destructure (fixes #&#8203;8729) (#&#8203;8756) (Victor Hom)
* 3608f06 Docs: Increase visibility of code of conduct (fixes #&#8203;8758) (#&#8203;8764) (Kai Cataldo)
* 673a58b Update: support multiple fixes in a report (fixes #&#8203;7348) (#&#8203;8101) (Toru Nagashima)
* 7a1bc38 Fix: don't pass default parserOptions to custom parsers (fixes #&#8203;8744) (#&#8203;8745) (Teddy Katz)
* c5b4052 Chore: enable computed-property-spacing on ESLint codebase (#&#8203;8760) (Teddy Katz)
* 3419f64 Docs: describe how to use formatters on the formatter demo page (#&#8203;8754) (Teddy Katz)
* a3ff8f2 Chore: combine tests in tests/lib/eslint.js and tests/lib/linter.js (#&#8203;8746) (Teddy Katz)
* b7cc1e6 Fix: Space-infix-ops should ignore type annotations in TypeScript (#&#8203;8341) (Reyad Attiyat)
* 46e73ee Fix: eslint --init installs wrong dependencies of popular styles (fixes #&#8203;7338) (#&#8203;8713) (Toru Nagashima)
* a82361b Chore: Prevent package-lock.json files from being created (fixes #&#8203;8742) (#&#8203;8747) (Teddy Katz)
* 5f81a68 New: Add eslintIgnore support to package.json (fixes #&#8203;8458) (#&#8203;8690) (Victor Hom)
* b5a70b4 Update: fix multiline binary operator/parentheses indentation (#&#8203;8719) (Teddy Katz)
* ab8b016 Update: fix MemberExpression indentation with "off" option (fixes #&#8203;8721) (#&#8203;8724) (Teddy Katz)
* eb5d12c Update: Add Fixer method to Linter API (#&#8203;8631) (Gyandeep Singh)
* 26a2daa Chore: Cache fs reads in ignored-paths (fixes #&#8203;8363) (#&#8203;8706) (Victor Hom)

---

### [`v4.1.1`](https://github.com/eslint/eslint/releases/v4.1.1)

* f307aa0 Fix: ensure configs from a plugin are cached separately (fixes #&#8203;8792) (#&#8203;8798) (Teddy Katz)
* 8b48ae8 Docs: Add doc on parser services (fixes #&#8203;8390) (#&#8203;8795) (Victor Hom)
* 0d041e7 Fix: avoid crashing when using baseConfig with extends (fixes #&#8203;8791) (#&#8203;8797) (Teddy Katz)
* 03213bb Chore: improve comment explanation of `indent` internal functions (#&#8203;8800) (Teddy Katz)
* d2e88ed Chore: Fix misleading comment in ConfigCache.js (#&#8203;8799) (Teddy Katz)

---

### [`v4.2.0`](https://github.com/eslint/eslint/releases/v4.2.0)

* e0f0101 Update: fix indentation of nested function parameters (fixes #&#8203;8892) (#&#8203;8900) (Teddy Katz)
* 9f95a3e Chore: remove unused helper method from `indent` (#&#8203;8901) (Teddy Katz)
* 11ffe6b Fix: no-regex-spaces rule incorrectly fixes quantified spaces (#&#8203;8773) (Keri Warr)
* 975dacf Update: fix indentation of EmptyStatements (fixes #&#8203;8882) (#&#8203;8885) (Teddy Katz)
* 88ed041 Build: Turnoff CI branch build (fixes #&#8203;8804) (#&#8203;8873) (Gyandeep Singh)
* 72f22eb Chore: replace is-my-json-valid with Ajv (#&#8203;8852) (Gajus Kuizinas)
* 7c8de92 Docs: Clarified PR guidelines in maintainer guide (#&#8203;8876) (Kevin Partington)
* d1fc408 Docs: Update CLA link in Contributing docs (#&#8203;8883) (Calvin Freitas)
* 931a9f1 Fix: indent false positive with multi-line await expression (#&#8203;8837) (薛定谔的猫)
* 3767cda Update: add no-sync option to allow at root level (fixes #&#8203;7985) (#&#8203;8859) (Victor Hom)
* 1ce553d Docs: Fix wording of minProperties in object-curly-newline (fixes #&#8203;8874) (#&#8203;8878) (solmsted)
* f00854e Fix: --quiet no longer fixes warnings (fixes #&#8203;8675) (#&#8203;8858) (Kevin Partington)
* b678535 Chore: Add collapsible block for config in ISSUE_TEMPLATE (#&#8203;8872) (Gyandeep Singh)
* 1f5bfc2 Update: Add always-multiline option to multiline-ternary (fixes #&#8203;8770) (#&#8203;8841) (Nathan Woltman)
* 22116f2 Fix: correct comma-dangle JSON schema (#&#8203;8864) (Evgeny Poberezkin)
* 676af9e Update: fix indentation of JSXExpressionContainer contents (fixes #&#8203;8832) (#&#8203;8850) (Teddy Katz)
* 330dd58 Chore: fix title of linter test suite (#&#8203;8861) (Teddy Katz)
* 60099ed Chore: enable for-direction rule on ESLint codebase (#&#8203;8853) (薛定谔的猫)
* e0d1a84 Chore: upgrade eslint-plugin-eslint-plugin & eslint-plugin-node (#&#8203;8856) (薛定谔的猫)
* 0780d86 Chore: remove identical tests (#&#8203;8851) (Teddy Katz)
* 5c3ac8e Fix: arrow-parens fixer gets tripped up with trailing comma in args (#&#8203;8838) (薛定谔的猫)
* c4f2e29 Build: fix race condition in demo (#&#8203;8827) (Teddy Katz)
* c693be5 New: Allow passing a function as `fix` option (fixes #&#8203;8039) (#&#8203;8730) (Ian VanSchooten)
* 8796d55 Docs: add missing item to 4.0 migration guide table of contents (#&#8203;8835) (薛定谔的猫)
* 742998c doc md update: false -> `false` (#&#8203;8825) (Erik Vold)
* ce969f9 Docs: add guidelines for patch release communication (fixes #&#8203;7277) (#&#8203;8823) (Teddy Katz)
* 5c83c99 Docs: Clarify arrow function parens in no-extra-parens (fixes #&#8203;8741) (#&#8203;8822) (Kevin Partington)
* 84d921d Docs: Added note about Node/CJS scoping to no-redeclare (fixes #&#8203;8814) (#&#8203;8820) (Kevin Partington)
* 85c9327 Update: fix parenthesized CallExpression indentation (fixes #&#8203;8790) (#&#8203;8802) (Teddy Katz)
* be8d354 Update: simplify variable declarator indent handling (fixes #&#8203;8785) (#&#8203;8801) (Teddy Katz)
* 9417818 Fix: no-debugger autofixer produced invalid syntax (#&#8203;8806) (Teddy Katz)
* 8698a92 New: getter-return rule (fixes #&#8203;8449) (#&#8203;8460) (薛定谔的猫)
* eac06f2 Fix: no-extra-parens false positives for variables called "let" (#&#8203;8808) (Teddy Katz)
* 616587f Fix: dot-notation autofix produces syntax errors for object called "let" (#&#8203;8807) (Teddy Katz)
* a53ef7e Fix: don't require a third argument in linter.verifyAndFix (fixes #&#8203;8805) (#&#8203;8809) (Teddy Katz)
* 5ad8b70 Docs: add minor formatting improvement to paragraph about parsers (#&#8203;8816) (Teddy Katz)

---

### [`v4.3.0`](https://github.com/eslint/eslint/releases/v4.3.0)

* 91dccdf Update: support more options in prefer-destructuring (#&#8203;8796) (Victor Hom)
* 3bebcfd Update: Support generator yields in no constant condition (#&#8203;8762) (Victor Hom)
* 96df8c9 Fix: Handle fixing objects containing comments (fixes #&#8203;8484) (#&#8203;8944) (Brian Schemp)
* e39d41d Docs: Make `peerDependencies` package.json snippet valid JSON (#&#8203;8971) (Sam Adams)
* a5fd101 Fix: duplicated error message if a crash occurs (fixes #&#8203;8964) (#&#8203;8965) (Teddy Katz)
* f8d122c Docs: trailing commas not allowed in json (#&#8203;8969) (Scott Fletcher)
* d09288a Chore: Use `output: null` to assert that a test case is not autofixed. (#&#8203;8960) (薛定谔的猫)
* e639358 Update: add question to confirm downgrade (fixes #&#8203;8870) (#&#8203;8911) (Toru Nagashima)
* 601039d Docs: fix badge in eslint-config-eslint readme (#&#8203;8954) (Teddy Katz)
* 3c231fa Update: add enforceInMethodNames to no-underscore-dangle (fixes #&#8203;7065) (#&#8203;7234) (Gabriele Petronella)
* 128591f Update: prefer-numeric-literals warns Number.parseInt (fixes #&#8203;8913) (#&#8203;8929) (Kevin Partington)
* 846f8b1 Docs: Clarified that core PRs require issue in maintainer guide (#&#8203;8927) (Kevin Partington)
* 55bc35d Fix: Avoid shell mangling during eslint --init (#&#8203;8936) (Anders Kaseorg)
* 10c3d78 Chore: fix misleading `indent` test (#&#8203;8925) (Teddy Katz)
* fb8005d Update: no-restricted-globals custom error messages (fixes #&#8203;8315) (#&#8203;8932) (Kevin Partington)
* a747b6f Chore: make minor improvements to `indent` internals (#&#8203;8947) (Teddy Katz)
* 1ea3723 Update: fix indentation of parenthesized MemberExpressions (fixes #&#8203;8924) (#&#8203;8928) (Teddy Katz)
* 9abc6f7 Update: fix BinaryExpression indentation edge case (fixes #&#8203;8914) (#&#8203;8930) (Teddy Katz)
* 0e90453 Docs: Fixing broken cyclomatic complexity link (fixes #&#8203;8396) (#&#8203;8937) (Chris Bargren)
* a8a8350 Chore: improve performance of `indent` rule (#&#8203;8905) (Teddy Katz)
* 764b2a9 Chore: update header info in `indent` (#&#8203;8926) (Teddy Katz)
* 597c217 Fix: confusing error if plugins from config is not an array (#&#8203;8888) (Calvin Freitas)
* 3c1dd6d Docs: add description of no-sync `allowAtRootLevel` option (fixes #&#8203;8902) (#&#8203;8906) (Teddy Katz)
* 933a9cf Chore: add a fuzzer to detect bugs in core rules (#&#8203;8422) (Teddy Katz)
* 45f8cd9 Docs: fix verifyAndFix result property name (#&#8203;8903) (Tino Vyatkin)
* 1a89e1c Docs: Fix always-multiline example in multiline-ternary docs (#&#8203;8904) (Nathan Woltman)

---

### [`v4.4.0`](https://github.com/eslint/eslint/releases/v4.4.0)

* 89196fd Upgrade: Espree to 3.5.0 (#&#8203;9074) (Gyandeep Singh)
* b3e4598 Fix: clarify AST and don't use `node.start`/`node.end` (fixes #&#8203;8956) (#&#8203;8984) (Toru Nagashima)
* 62911e4 Update: Add ImportDeclaration option to indent rule (#&#8203;8955) (David Irvine)
* de75f9b Chore: enable object-curly-newline & object-property-newline.(fixes #&#8203;9042) (#&#8203;9068) (薛定谔的猫)
* 5ae8458 Docs: fix typo in object-shorthand.md (#&#8203;9066) (Jon Berry)
* c3d5b39 Docs: clarify options descriptions (fixes #&#8203;8875) (#&#8203;9060) (Brandon Mailhiot)
* 37158c5 Docs: clarified behavior of globalReturn option (fixes #&#8203;8953) (#&#8203;9058) (Brandon Mailhiot)
* c2f3553 Docs: Update example for MemberExpression option of indent (fixes #&#8203;9056) (#&#8203;9057) (Jeff)
* 78a85e0 Fix: no-extra-parens incorrectly reports async function expressions (#&#8203;9035) (薛定谔的猫)
* c794f86 Fix: getter-return reporting method named 'get' (fixes #&#8203;8919) (#&#8203;9004) (薛定谔的猫)
* d0f78ec Docs: update rule deprecation policy (fixes #&#8203;8635) (#&#8203;9033) (Teddy Katz)
* 5ab282f Fix: Print error message in bin/eslint.js (fixes #&#8203;9011) (#&#8203;9041) (Victor Hom)
* 50e3cf3 Docs: Update sort-keys doc to define natural ordering (fixes #&#8203;9043) (#&#8203;9045) (Karan Sharma)
* 7ecfe6a Chore: enable eslint-plugin/test-case-property-ordering (#&#8203;9040) (薛定谔的猫)
* ad32697 Upgrade: js-yaml to 3.9.1 (refs #&#8203;9011) (#&#8203;9044) (Teddy Katz)
* 66c1d43 Docs: Create SUPPORT.md (#&#8203;9031) (Teddy Katz)
* 7247b6c Update: handle indentation of custom destructuring syntax (fixes #&#8203;8990) (#&#8203;9027) (Teddy Katz)
* cdb82f2 Fix: padding-line-between-statements crash on semicolons after blocks (#&#8203;8748) (Alexander Madyankin)
* 3141872 Chore: remove unnecessary eslint-disable comments in codebase (#&#8203;9032) (Teddy Katz)
* 0f97279 Fix: refactor no-multi-spaces to avoid regex backtracking (fixes #&#8203;9001) (#&#8203;9008) (Teddy Katz)
* b74514d Fix: refactor RuleContext to not modify report locations (fixes #&#8203;8980) (#&#8203;8997) (Teddy Katz)
* 31d7fd2 Fix: inconsistent `indent` behavior on computed properties (fixes #&#8203;8989) (#&#8203;8999) (Teddy Katz)
* 3393894 Fix: avoid reporting the entire AST for missing rules (#&#8203;8998) (Teddy Katz)
* b3b95b8 Chore: enable additional rules on ESLint codebase (#&#8203;9013) (Teddy Katz)
* 9b6c552 Upgrade: eslint-plugin-eslint-plugin@&#8203;0.8.0 (#&#8203;9012) (薛定谔的猫)
* acbe86a Chore: disallow .substr and .substring in favor of .slice (#&#8203;9010) (Teddy Katz)
* d0536d6 Chore: Optimizes adding Linter methods (fixes #&#8203;9000) (#&#8203;9007) (Sean C Denison)
* 0a0401f Chore: fix spelling error. (#&#8203;9003) (薛定谔的猫)
* 3d020b9 Update: emit a warning for ecmaFeatures rather than throwing an error (#&#8203;8974) (Teddy Katz)
* d2f8f9f Fix: include name of invalid config in validation messages (fixes #&#8203;8963) (#&#8203;8973) (Teddy Katz)
* c3ee46b Chore: fix misleading comment in RuleTester (#&#8203;8995) (Teddy Katz)

---

### [`v4.4.1`](https://github.com/eslint/eslint/releases/v4.4.1)

* ec93614 Fix: no-multi-spaces to avoid reporting consecutive tabs (fixes #&#8203;9079) (#&#8203;9087) (Teddy Katz)

---

### [`v4.5.0`](https://github.com/eslint/eslint/releases/v4.5.0)

* decdd2c Update: allow arbitrary nodes to be ignored in `indent` (fixes #&#8203;8594) (#&#8203;9105) (Teddy Katz)
* 79062f3 Update: fix indentation of multiline `new.target` expressions (#&#8203;9116) (Teddy Katz)
* d00e24f Upgrade: `chalk` to 2.x release (#&#8203;9115) (Stephen Edgar)
* 6ef734a Docs: add missing word in processor documentation (#&#8203;9106) (Teddy Katz)
* a4f53ba Fix: Include files with no messages in junit results (#&#8203;9093) (#&#8203;9094) (Sean DuBois)
* 1d6a9c0 Chore: enable eslint-plugin/test-case-shorthand-strings (#&#8203;9067) (薛定谔的猫)
* f8add8f Fix: don't autofix with linter.verifyAndFix when `fix: false` is used (#&#8203;9098) (Teddy Katz)
* 77bcee4 Docs: update instructions for adding TSC members (#&#8203;9086) (Teddy Katz)
* bd09cd5 Update: avoid requiring NaN spaces of indentation (fixes #&#8203;9083) (#&#8203;9085) (Teddy Katz)
* c93a853 Chore: Remove extra space in blogpost template (#&#8203;9088) (Kai Cataldo)

---

### [`v4.6.0`](https://github.com/eslint/eslint/releases/v4.6.0)

* 56dd769 Docs: fix link format in prefer-arrow-callback.md (#&#8203;9198) (Vse Mozhet Byt)
* 6becf91 Update: add eslint version to error output. (fixes #&#8203;9037) (#&#8203;9071) (薛定谔的猫)
* 0e09973 New: function-paren-newline rule (fixes #&#8203;6074) (#&#8203;8102) (Teddy Katz)
* 88a64cc Chore: Make parseJsonConfig() a pure function in Linter (#&#8203;9186) (Teddy Katz)
* 1bbac51 Fix: avoid breaking eslint-plugin-eslint-comments (fixes #&#8203;9193) (#&#8203;9196) (Teddy Katz)
* 3e8b70a Fix: off-by-one error in eslint-disable comment checking (#&#8203;9195) (Teddy Katz)
* 73815f6 Docs: rewrite prefer-arrow-callback documentation (fixes #&#8203;8950) (#&#8203;9077) (Charles E. Morgan)
* 0d3a854 Chore: avoid mutating report descriptors in report-translator (#&#8203;9189) (Teddy Katz)
* 2db356b Update: no-unused-vars Improve message to include the allowed patterns (#&#8203;9176) (Eli White)
* 8fbaf0a Update: Add configurability to generator-star-spacing (#&#8203;8985) (Ethan Rutherford)
* 8ed779c Chore: remove currentScopes property from Linter instances (refs #&#8203;9161) (#&#8203;9187) (Teddy Katz)
* af4ad60 Fix: Handle error when running init without npm (#&#8203;9169) (Gabriel Aumala)
* 4b94c6c Chore: make parse() a pure function in Linter (refs #&#8203;9161) (#&#8203;9183) (Teddy Katz)
* 1be5634 Chore: don't make Linter a subclass of EventEmitter (refs #&#8203;9161) (#&#8203;9177) (Teddy Katz)
* e95af9b Chore: don't include internal test helpers in npm package (#&#8203;9160) (Teddy Katz)
* 6fb32e1 Chore: avoid using private Linter APIs in astUtils tests (refs #&#8203;9161) (#&#8203;9173) (Teddy Katz)
* de6dccd Docs: add documentation for Linter methods (refs #&#8203;6525) (#&#8203;9151) (Teddy Katz)
* 2d90030 Chore: remove unused assignment. (#&#8203;9182) (薛定谔的猫)
* d672aef Chore: refactor reporting logic (refs #&#8203;9161) (#&#8203;9168) (Teddy Katz)
* 5ab0434 Fix: indent crash on sparse arrays with "off" option (fixes #&#8203;9157) (#&#8203;9166) (Teddy Katz)
* c147b97 Chore: Make SourceCodeFixer accept text instead of a SourceCode instance (#&#8203;9178) (Teddy Katz)
* f127423 Chore: avoid using private Linter APIs in Linter tests (refs #&#8203;9161) (#&#8203;9175) (Teddy Katz)
* 2334335 Chore: avoid using private Linter APIs in SourceCode tests (refs #&#8203;9161) (#&#8203;9174) (Teddy Katz)
* 2dc243a Chore: avoid using internal Linter APIs in RuleTester (refs #&#8203;9161) (#&#8203;9172) (Teddy Katz)
* d6e436f Fix: no-extra-parens reported some parenthesized IIFEs (fixes #&#8203;9140) (#&#8203;9158) (Teddy Katz)
* e6b115c Build: Add an edit link to the rule docs’ metadata (#&#8203;9049) (Jed Fox)
* fcb7bb4 Chore: avoid unnecessarily complex forEach calls in no-extra-parens (#&#8203;9159) (Teddy Katz)
* ffa021e Docs: quotes rule - when does \n require backticks (#&#8203;9135) (avimar)
* 60c5148 Chore: improve coverage in lib/*.js (#&#8203;9130) (Teddy Katz)

---

### [`v4.6.1`](https://github.com/eslint/eslint/releases/v4.6.1)

* bdec46d Build: avoid process leak when generating website (#&#8203;9217) (Teddy Katz)
* cb74b87 Fix: avoid adding globals when an env is used with `false` (fixes #&#8203;9202) (#&#8203;9203) (Teddy Katz)
* f9b7544 Docs: Correct a typo in generator-star-spacing documentation (#&#8203;9205) (Ethan Rutherford)
* e5c5e83 Build: Fixing issue with docs generation (Fixes #&#8203;9199) (#&#8203;9200) (Ilya Volodin)

---

### [`v4.7.0`](https://github.com/eslint/eslint/releases/v4.7.0)

* 787b78b Upgrade: Espree v3.5.1 (fixes #&#8203;9153) (#&#8203;9314) (Brandon Mills)
* 1488b51 Update: run rules after `node.parent` is already set (fixes #&#8203;9122) (#&#8203;9283) (Teddy Katz)
* 4431d68 Docs: fix wrong config in max-len example. (#&#8203;9309) (薛定谔的猫)
* 7d24dde Docs: Fix code snippet to refer to the correct option (#&#8203;9313) (Ruben Tytgat)
* 12388d4 Chore: rewrite parseListConfig for a small perf gain. (#&#8203;9300) (薛定谔的猫)
* ce1f084 Update: fix MemberExpression handling in no-extra-parens (fixes #&#8203;9156) (jackyho112)
* 0c720a3 Update: allow autofixing when using processors (fixes #&#8203;7510) (#&#8203;9090) (Teddy Katz)
* 838df76 Chore: upgrade deps. (#&#8203;9289) (薛定谔的猫)
* f12def6 Update: indent flatTernary option to handle `return` (fixes #&#8203;9285) (#&#8203;9296) (Teddy Katz)
* e220687 Fix: remove autofix for var undef inits (fixes #&#8203;9231) (#&#8203;9288) (Victor Hom)
* 002e199 Docs: fix no-restricted-globals wrong config. (#&#8203;9305) (薛定谔的猫)
* fcfe91a Docs: fix wrong config in id-length example. (#&#8203;9303) (薛定谔的猫)
* 2731f94 Update: make newline-per-chained-call fixable (#&#8203;9149) (João Granado)
* 61f1093 Chore: avoid monkeypatching Linter instances in RuleTester (#&#8203;9276) (Teddy Katz)
* 28929cb Chore: remove Linter#reset (refs #&#8203;9161) (#&#8203;9268) (Teddy Katz)
* abc8634 Build: re-run browserify when generating site (#&#8203;9275) (Teddy Katz)
* 7685fed Fix: IIFE and arrow functions in no-invalid-this (fixes #&#8203;9126) (#&#8203;9258) (Toru Nagashima)
* 2b1eba2 Chore: enable eslint-plugin/no-deprecated-context-methods (#&#8203;9279) (Teddy Katz)
* 981f933 Fix: reuse the AST of source code object in verify (#&#8203;9256) (Toru Nagashima)
* cd698ba Docs: move RuleTester documentation to Node.js API page (#&#8203;9273) (Teddy Katz)
* 4ae7ad3 Docs: fix inaccuracy in `npm run perf` description (#&#8203;9274) (Teddy Katz)
* cad45bd Docs: improve documentation for rule contexts (#&#8203;9272) (Teddy Katz)
* 3b0c6fd Chore: remove extraneous linter properties (refs #&#8203;9161) (#&#8203;9267) (Teddy Katz)
* c3231b3 Docs: Fix typo in array-bracket-newline.md (#&#8203;9269) (宋文强)
* 51132d6 Fix: Formatters keep trailing '.' if preceded by a space (fixes #&#8203;9154) (#&#8203;9247) (i-ron-y)
* 88d5d4d Chore: remove undocumented Linter#markVariableAsUsed method (refs #&#8203;9161) (#&#8203;9266) (Teddy Katz)
* 09414cf Chore: remove internal Linter#getDeclaredVariables method (refs #&#8203;9161) (#&#8203;9264) (Teddy Katz)
* f31f59d Chore: prefer smaller scope for variables in codebase (#&#8203;9265) (Teddy Katz)
* 3693e4e Chore: remove undocumented Linter#getScope method (#&#8203;9253) (Teddy Katz)
* 5d7eb81 Chore: refactor config hash caching in CLIEngine (#&#8203;9260) (Teddy Katz)
* 1a76c4d Chore: remove SourceCode passthroughs from Linter.prototype (refs #&#8203;9161) (#&#8203;9263) (Teddy Katz)
* 40ae27b Chore: avoid relying on Linter#getScope/markVariableAsUsed in tests (#&#8203;9252) (Teddy Katz)
* b383d81 Chore: make executeOnFile a pure function in CLIEngine (#&#8203;9262) (Teddy Katz)
* 5e0e579 Chore: avoid internal SourceCode methods in Linter tests (refs #&#8203;9161) (#&#8203;9223) (Teddy Katz)
* adab827 Chore: remove unused eslint-disable comment (#&#8203;9251) (Teddy Katz)
* 31e4ec8 Chore: use consistent names for apply-disable-directives in tests (#&#8203;9246) (Teddy Katz)
* 7ba46e6 Fix: shebang error in eslint-disable-new-line; add tests (fixes #&#8203;9238) (#&#8203;9240) (i-ron-y)
* 8f6546c Chore: remove undocumented defaults() method (refs #&#8203;9161) (#&#8203;9237) (Teddy Katz)
* 82d8b73 Docs: Fix error in example code for sort-imports (fixes #&#8203;8734) (#&#8203;9245) (i-ron-y)
* a32ec36 Update: refactor eslint-disable comment processing (#&#8203;9216) (Teddy Katz)
* 583f0b8 Chore: avoid using globals in CLIEngine tests (#&#8203;9242) (Teddy Katz)
* c8bf687 Chore: upgrade eslint-plugin-eslint-plugin@&#8203;1.0.0 (#&#8203;9234) (薛定谔的猫)
* 3c41a05 Chore: always normalize rules to new API in rules.js (#&#8203;9236) (Teddy Katz)
* c5f4227 Chore: move logic for handling missing rules to rules.js (#&#8203;9235) (Teddy Katz)
* bf1e344 Chore: create report translators lazily (#&#8203;9221) (Teddy Katz)
* 2eedc1f Chore: remove currentFilename prop from Linter instances (refs #&#8203;9161) (#&#8203;9219) (Teddy Katz)
* 5566e94 Docs: Replace misleading CLA links (#&#8203;9133) (#&#8203;9232) (i-ron-y)
* c991630 Chore: remove ConfigOps.normalize in favor of ConfigOps.getRuleSeverity (#&#8203;9224) (Teddy Katz)
* 171962a Chore: remove internal Linter#getAncestors helper (refs #&#8203;9161) (#&#8203;9222) (Teddy Katz)
* a567499 Chore: avoid storing list of problems on Linter instance (refs #&#8203;9161) (#&#8203;9214) (Teddy Katz)
* ed6d088 Chore: avoid relying on undocumented Linter#getFilename API in tests (#&#8203;9218) (Teddy Katz)

---

### [`v4.7.1`](https://github.com/eslint/eslint/releases/v4.7.1)

* 08656db Fix: Handle nested disable directive correctly (fixes #&#8203;9318) (#&#8203;9322) (Gyandeep Singh)
* 9226495 Revert "Chore: rewrite parseListConfig for a small perf gain." (#&#8203;9325) (薛定谔的猫)

---

### [`v4.7.2`](https://github.com/eslint/eslint/releases/v4.7.2)

* 4f87732 Fix: Revert setting node.parent early (fixes #&#8203;9331) (#&#8203;9336) (Teddy Katz)

---

### [`v4.8.0`](https://github.com/eslint/eslint/releases/v4.8.0)

* 3f2b908 New: add option to report unused eslint-disable directives (fixes #&#8203;9249) (#&#8203;9250) (Teddy Katz)
* ff2be59 Fix: dot notation rule failing to catch string template (fixes #&#8203;9350) (#&#8203;9357) (Phil Quinn)
* b1372da Chore: remove sourceCode property from Linter (refs #&#8203;9161) (#&#8203;9363) (Teddy Katz)
* cef6f8c Docs: remove line about removing rules from semver policy (#&#8203;9367) (Teddy Katz)
* 06efe87 Fix: Add meta element with charset attribute. (#&#8203;9365) (H1Gdev)
* 458ca67 Docs: update architecture page (fixes #&#8203;9337) (#&#8203;9345) (Victor Hom)
* 1c6bc67 Fix: special EventEmitter keys leak information about other rules (#&#8203;9328) (Teddy Katz)
* d593e61 Docs: update eslint.org links to use https (#&#8203;9358) (Teddy Katz)
* 38d0cb2 Fix: fix wrong code-path about try-for-in (fixes #&#8203;8848) (#&#8203;9348) (Toru Nagashima)
* 434d9e2 Fix: Invalid font-size property value issue. (#&#8203;9341) (H1Gdev)
* a7668c2 Chore: Remove unnecessary slice from logging utility (#&#8203;9343) (Gyandeep Singh)
* 2ff6fb6 Chore: remove unused arguments in codebase (#&#8203;9340) (Teddy Katz)

---

### [`v4.9.0`](https://github.com/eslint/eslint/releases/v4.9.0)

* 85388fb Fix: Correct error and test messages to fit config search path (#&#8203;9428) (Jonathan Pool)
* 62a323c Fix: Add class options for `lines-around-comment` (fixes #&#8203;8564) (#&#8203;8565) (Ed Lee)
* 8eb4aae New: multiline-comment-style rule (fixes #&#8203;8320) (#&#8203;9389) (薛定谔的猫)
* db41408 Chore: avoid applying eslint-env comments twice (#&#8203;9278) (Teddy Katz)
* febb897 Chore: avoid loose equality assertions (#&#8203;9415) (Teddy Katz)
* 2247efa Update: Add FunctionExpression to require-jsdoc (fixes #&#8203;5867) (#&#8203;9395) (Kai Cataldo)
* 6791d18 Docs: Corrected noun to verb. (#&#8203;9438) (Jonathan Pool)
* b02fbb6 Update: custom messages for no-restricted-* (refs #&#8203;8400) (Maja Wichrowska)
* 02732bd Docs: Reorganized to avoid misunderstandings. (#&#8203;9434) (Jonathan Pool)
* d9466b8 Docs: Correct time forecast for tests. (#&#8203;9432) (Jonathan Pool)
* f7ed84f Docs: Add instruction re home-directory config files (refs #&#8203;7729) (#&#8203;9426) (Jonathan Pool)
* 30d018b Chore: Add Aladdin-ADD & VictorHom to README (#&#8203;9424) (Kai Cataldo)
* 2d8a303 Docs: fix examples for prefer-numeric-literals (#&#8203;9155) (Lutz Lengemann)
* d7610f5 Docs: Add jquery warning to prefer-destructuring (#&#8203;9409) (Thomas Grainger)
* e835dd1 Docs: clarify no-mixed-operators (fixes #&#8203;8051) (Ruxandra Fediuc)
* 51360c8 Docs: update block-spacing details (fixes #&#8203;8743) (#&#8203;9375) (Victor Hom)
* 6767857 Update: fix ignored nodes in indent rule when using tabs (fixes #&#8203;9392) (#&#8203;9393) (Robin Houston)
* 37dde77 Chore: Refactor SourceCode#getJSDocComment (#&#8203;9403) (Kai Cataldo)
* 9fedd51 Chore: Add missing space in blog post template (#&#8203;9407) (Kevin Partington)
* 7654c99 Docs: add installing prerequisites in readme. (#&#8203;9401) (薛定谔的猫)
* 786cc73 Update: Add "consistent" option to array-bracket-newline (fixes #&#8203;9136) (#&#8203;9206) (Ethan Rutherford)
* e171f6b Docs: add installing prerequisites. (#&#8203;9394) (薛定谔的猫)
* 74dfc87 Docs: update doc for class-methods-use-this (fixes #&#8203;8910) (#&#8203;9374) (Victor Hom)
* b4a9dbf Docs: show console call with no-restricted-syntax (fixes #&#8203;7806) (#&#8203;9376) (Victor Hom)
* 8da525f Fix: recognise multiline comments as multiline arrays (fixes #&#8203;9211) (#&#8203;9369) (Phil Quinn)
* c581b77 Chore: Error => TypeError (#&#8203;9390) (薛定谔的猫)
* ee99876 New: lines-between-class-members rule (fixes #&#8203;5949) (#&#8203;9141) (薛定谔的猫)
* 9d3f5ad Chore: report unused eslint-disable directives in ESLint codebase (#&#8203;9371) (Teddy Katz)
* 1167638 Update: add allowElseIf option to no-else-return (fixes #&#8203;9228) (#&#8203;9229) (Thomas Grainger)
* 4567ab1 New: Add the fix-dry-run flag (fixes #&#8203;9076) (#&#8203;9073) (Rafał Ruciński)

---

### [`v4.10.0`](https://github.com/eslint/eslint/releases/v4.10.0)

* bb6e60a Fix: Improve the doc for no-restricted-modules rule (fixes #&#8203;9437) (#&#8203;9495) (vibss2397)
* c529de9 Docs: Amend rule document to correct and complete it (refs #&#8203;6251). (#&#8203;9498) (Jonathan Pool)
* f9c6673 Chore: Add tests to cover array and object values and leading commas. (#&#8203;9502) (Jonathan Pool)
* 9169258 Chore: remove `npm run check-commit` script (#&#8203;9513) (Teddy Katz)
* 7d390b2 Docs: Revise contributor documentation on issue labels. (#&#8203;9469) (Jonathan Pool)
* d80b9d0 Fix: no-var don't fix globals (fixes #&#8203;9520) (#&#8203;9525) (Toru Nagashima)
* b8aa071 Fix: allow linting the empty string from stdin (fixes #&#8203;9515) (#&#8203;9517) (Teddy Katz)
* 350a72c Chore: regex.test => string.startsWith (#&#8203;9518) (薛定谔的猫)
* de0bef4 Chore: remove obsolete eslintbot templates (#&#8203;9512) (Teddy Katz)
* 720b6d5 Docs: Update ISSUE_TEMPLATE.md (#&#8203;9504) (薛定谔的猫)
* 2fa64b7 Fix: should not convert non-consecutive line comments to a single blo… (#&#8203;9475) (薛定谔的猫)
* 9725146 Fix: multiline-comment-style fix produces invalid code (fixes #&#8203;9461). (#&#8203;9463) (薛定谔的猫)
* b12cff8 Fix: Expected order of jsdoc tags (fixes #&#8203;9412) (#&#8203;9451) (Orlando Wenzinger)
* f054ab5 Docs: add `.md` to link (for github users) (#&#8203;9501) (薛定谔的猫)
* 5ed9cfc Docs: Correct violations of “Variable Declarations” in Code Conventions (#&#8203;9447) (Jonathan Pool)
* 3171097 Docs: Clears confusion on usage of global and local plugins.(#&#8203;9492) (Vasili Sviridov)
* 3204773 Chore: enable max-len. (#&#8203;9414) (薛定谔的猫)
* 0f71fef Docs: Unquote booleans in lines-between-class-members docs (#&#8203;9497) (Brandon Mills)
* b3d7532 Docs: use consistent terminology & fix link etc. (#&#8203;9490) (薛定谔的猫)
* 87db8ae Docs: Fix broken links (#&#8203;9488) (gpiress)
* 51bdb2f Docs: Incorrect link to related rule (#&#8203;9477) (Gavin King)
* 1a962e8 Docs: Add FAQ for when ESLint cannot find plugin (#&#8203;9467) (Kevin Partington)
* 8768b2d Fix: multiline-comment-style autofixer added trailing space (#&#8203;9454) (Teddy Katz)
* e830aa1 Fix: multiline-comment-style reports block comments followed by code (#&#8203;9450) (Teddy Katz)
* b12e5fe Docs: Repair broken links and add migration links. (#&#8203;9473) (Jonathan Pool)
* eca01ed Docs: Add missing info about special status of home-dir config files. (#&#8203;9472) (Jonathan Pool)
* eb8cfb1 Fix: change err report in constant condition (fixes #&#8203;9398) (#&#8203;9436) (Victor Hom)
* da77eb4 Chore: Revise no-config-file test to prevent false failure. (#&#8203;9443) (Jonathan Pool)
* 47e5f6f Docs: ensure "good commit message" examples actually follow guidelines (#&#8203;9466) (Teddy Katz)
* ebb530d Update: Don't ignore comments (no-trailing-spaces) (#&#8203;9416) (Chris van Marle)
* 5012661 Build: fix `npm run profile` script (fixes #&#8203;9397) (#&#8203;9455) (Teddy Katz)
* ecac0fd Docs: Remove blockBindings references (#&#8203;9446) (Jan Pilzer)
* 0b89865 Chore: ensure tests for internal rules get run (#&#8203;9453) (Teddy Katz)
* 052c504 Docs: suggest deleting branches after merging PRs (#&#8203;9449) (Teddy Katz)
* b31e55a Chore: move internal rules out of lib/ (#&#8203;9448) (Teddy Katz)
* a7521e3 Docs: improve examples for multiline-comment-style (#&#8203;9440) (Teddy Katz)

---

### [`v4.11.0`](https://github.com/eslint/eslint/releases/v4.11.0)

* d4557a6 Docs: disallow use of the comma operator using no-restricted-syntax (#&#8203;9585) (薛定谔的猫)
* d602f9e Upgrade: espree v3.5.2 (#&#8203;9611) (Kai Cataldo)
* 4def876 Chore: avoid handling rules instances in config-validator (#&#8203;9364) (Teddy Katz)
* fe5ac7e Chore: fix incorrect comment in safe-emitter.js (#&#8203;9605) (Teddy Katz)
* 6672fae Docs: Fixed a typo on lines-between-class-members doc (#&#8203;9603) (Moinul Hossain)
* 980ecd3 Chore: Update copyright and license info (#&#8203;9599) (薛定谔的猫)
* cc2c7c9 Build: use Node 8 in appveyor (#&#8203;9595) (薛定谔的猫)
* 2542f04 Docs: Add missing options for `lines-around-comment` (#&#8203;9589) (Clément Fiorio)
* b6a7490 Build: ensure fuzzer tests get run with `npm test` (#&#8203;9590) (Teddy Katz)
* 1073bc5 Build: remove shelljs-nodecli (refs #&#8203;9533) (#&#8203;9588) (Teddy Katz)
* 7e3bf6a Fix: edge-cases of semi-style (#&#8203;9560) (Toru Nagashima)
* e5a37ce Fix: object-curly-newline for flow code (#&#8203;9458) (Tiddo Langerak)
* 9064b9c Chore: add equalTokens in ast-utils. (#&#8203;9500) (薛定谔的猫)
* b7c5b19 Fix: Correct [object Object] output of error.data. (#&#8203;9561) (Jonathan Pool)
* 51c8cf0 Docs: Disambiguate definition of Update tag (#&#8203;9584) (Jonathan Pool)
* afc3c75 Docs: clarify what eslint-config-eslint is (#&#8203;9582) (Teddy Katz)
* aedae9d Docs: fix spelling in valid-typeof example (#&#8203;9574) (Maksim Degtyarev)
* 4c5aaf3 Docs: Fix typo in no-underscore-dangle rule (#&#8203;9567) (Fabien Lucas)
* 3623600 Chore: upgrade ajv@&#8203;5.3.0 (#&#8203;9557) (薛定谔的猫)
* 1b606cd Chore: Remove an indirect dependency on jsonify (#&#8203;9444) (Rouven Weßling)
* 4d7d7ab Update: Resolve npm installed formatters (#&#8203;5900) (#&#8203;9464) (Tom Erik Støwer)
* accc490 Fix: Files with no failures get "passing" testcase (#&#8203;9547) (Samuel Levy)
* ab0f66d Docs: Add examples to better show rule coverage. (#&#8203;9548) (Jonathan Pool)
* 88d2303 Chore: Add object-property-newline tests to increase coverage. (#&#8203;9553) (Jonathan Pool)
* 7f37b1c Build: test Node 9 on Travis (#&#8203;9556) (Teddy Katz)
* acccfbd Docs: Minor rephrase in `no-invalid-this`. (#&#8203;9542) (Francisc)
* 8f9c0fe Docs: improve id-match usage advice (#&#8203;9544) (Teddy Katz)
* a9606a3 Fix: invalid tests with super (fixes #&#8203;9539) (#&#8203;9545) (Teddy Katz)
* 8e1a095 Chore: enable a modified version of multiline-comment-style on codebase (#&#8203;9452) (Teddy Katz)
* cb60285 Chore: remove commented test for HTML formatter (#&#8203;9532) (Teddy Katz)
* 06b491e Docs: fix duplicate entries in changelog (#&#8203;9530) (Teddy Katz)
* 2224733 Chore: use eslint-plugin-rulesdir instead of --rulesdir for self-linting (#&#8203;9164) (Teddy Katz)
* 9cf4ebe Docs: add .md to link(for github users) (#&#8203;9529) (薛定谔的猫)

---

### [`v4.12.0`](https://github.com/eslint/eslint/releases/v4.12.0)

* 76dab18 Upgrade: doctrine@&#8203;^2.0.2 (#&#8203;9656) (Kevin Partington)
* 28c9c8e New: add a Linter#defineParser function (#&#8203;9321) (Ives van Hoorne)
* 5619910 Update: Add autofix for `sort-vars` (#&#8203;9496) (Trevin Hofmann)
* 71eedbf Update: add `beforeStatementContinuationChars` to semi (fixes #&#8203;9521) (#&#8203;9594) (Toru Nagashima)
* 4118f14 New: Adds implicit-arrow-linebreak rule (refs #&#8203;9510) (#&#8203;9629) (Sharmila Jesupaul)
* 208fb0f Fix: Use XML 1.1 on XML formatters (fixes #&#8203;9607) (#&#8203;9608) (Daniel Reigada)
* 6e04f14 Upgrade: `globals` to 11.0.1 (fixes #&#8203;9614) (#&#8203;9632) (Toru Nagashima)
* e13d439 Fix: space-in-parens crash (#&#8203;9655) (Toru Nagashima)
* 92171cc Docs: Updating migration guide for single-line disable (#&#8203;9385) (Justin Helmer)
* f39ffe7 Docs: remove extra punctuation from readme (#&#8203;9640) (Teddy Katz)
* a015234 Fix: prefer-destructuring false positive on "super" (fixes #&#8203;9625) (#&#8203;9626) (Kei Ito)
* 0cf081e Update: add importNames option to no-restricted-imports (#&#8203;9506) (Benjamin R Gibson)
* 332c214 Docs: Add @&#8203;platinumazure to TSC (#&#8203;9618) (Ilya Volodin)

---

### [`v4.12.1`](https://github.com/eslint/eslint/releases/v4.12.1)

* 1e362a0 Revert "Fix: Use XML 1.1 on XML formatters (fixes #&#8203;9607) (#&#8203;9608)" (#&#8203;9667) (Kevin Partington)

---

### [`v4.13.0`](https://github.com/eslint/eslint/releases/v4.13.0)

* 256481b Update: update handling of destructuring in camelcase (fixes #&#8203;8511) (#&#8203;9468) (Erin)
* d067ae1 Docs: Don’t use undocumented array-style configuration for max-len (#&#8203;9690) (Jed Fox)
* 1ad3091 Chore: fix test-suite to work with node master (#&#8203;9688) (Myles Borins)
* cdb1488 Docs: Adds an example with try/catch. (#&#8203;9672) (Jaap Taal)

---

### [`v4.13.1`](https://github.com/eslint/eslint/releases/v4.13.1)

* b72dc83 Fix: eol-last allow empty-string to always pass (refs #&#8203;9534) (#&#8203;9696) (Kevin Partington)
* d80aa7c Fix: camelcase destructure leading/trailing underscore (fixes #&#8203;9700) (#&#8203;9701) (Kevin Partington)
* d49d9d0 Docs: Add missing period to the README (#&#8203;9702) (Kevin Partington)
* 4564fe0 Chore: no-invalid-meta crash if no export assignment (refs #&#8203;9534) (#&#8203;9698) (Kevin Partington)

---

### [`v4.14.0`](https://github.com/eslint/eslint/releases/v4.14.0)

* be2f57e Update: support separate requires in one-var. (fixes #&#8203;6175) (#&#8203;9441) (薛定谔的猫)
* 370d614 Docs: Fix typos (#&#8203;9751) (Jed Fox)
* 8196c45 Chore: Reorganize CLI options and associated docs (#&#8203;9758) (Kevin Partington)
* 75c7419 Update: Logical-and is counted in `complexity` rule (fixes #&#8203;8535) (#&#8203;9754) (Kevin Partington)
* eb4b1e0 Docs: reintroduce misspelling in `valid-typeof` example (#&#8203;9753) (Teddy Katz)
* ae51eb2 New: Add allowImplicit option to array-callback-return (fixes #&#8203;8539) (#&#8203;9344) (James C. Davis)
* e9d5dfd Docs: improve no-extra-parens formatting (#&#8203;9747) (Rich Trott)
* 37d066c Chore: Add unit tests for overrides glob matching. (#&#8203;9744) (Robert Jackson)
* 805a94e Chore: Fix typo in CLIEngine test name (#&#8203;9741) (@&#8203;scriptdaemon)
* 1c2aafd Update: Improve parser integrations (fixes #&#8203;8392) (#&#8203;8755) (Toru Nagashima)
* 4ddc131 Upgrade: debug@&#8203;^3.1.0 (#&#8203;9731) (Kevin Partington)
* f252c19 Docs: Make the lint message `source` property a little more subtle (#&#8203;9735) (Jed Fox)
* 5a5c23c Docs: fix the link to contributing page (#&#8203;9727) (Victor Hom)
* f44ce11 Docs: change beginner to good first issue label text (#&#8203;9726) (Victor Hom)
* 14baa2e Chore: improve arrow-body-style error message (refs #&#8203;5498) (#&#8203;9718) (Teddy Katz)
* f819920 Docs: fix typos (#&#8203;9723) (Thomas Broadley)
* 43d4ba8 Fix: false positive on rule`lines-between-class-members` (fixes #&#8203;9665) (#&#8203;9680) (sakabar)

---

### [`v4.15.0`](https://github.com/eslint/eslint/releases/v4.15.0)

* 6ab04b5 New: Add context.report({ messageId }) (fixes #&#8203;6740) (#&#8203;9165) (Jed Fox)
* fc7f404 Docs: add url to each of the rules (refs #&#8203;6582) (#&#8203;9788) (Patrick McElhaney)
* fc44da9 Docs: fix sort-imports rule block language (#&#8203;9805) (ferhat elmas)
* 65f0176 New: CLIEngine#getRules() (refs #&#8203;6582) (#&#8203;9782) (Patrick McElhaney)
* c64195f Update: More detailed assert message for rule-tester (#&#8203;9769) (Weijia Wang)
* 9fcfabf Fix: no-extra-parens false positive (fixes: #&#8203;9755) (#&#8203;9795) (Erin)
* 61e5fa0 Docs: Add table of contents to Node.js API docs (#&#8203;9785) (Patrick McElhaney)
* 4c87f42 Fix: incorrect error messages of no-unused-vars (fixes #&#8203;9774) (#&#8203;9791) (akouryy)
* bbabf34 Update: add `ignoreComments` option to `indent` rule (fixes #&#8203;9018) (#&#8203;9752) (Kevin Partington)
* db431cb Docs: HTTP -> HTTPS (fixes #&#8203;9768) (#&#8203;9768) (Ronald Eddy Jr)
* cbf0fb9 Docs: describe how to feature-detect scopeManager/visitorKeys support (#&#8203;9764) (Teddy Katz)
* f7dcb70 Docs: Add note about "patch release pending" label to maintainer guide (#&#8203;9763) (Teddy Katz)

---

### [`v4.16.0`](https://github.com/eslint/eslint/releases/v4.16.0)

* e26a25f Update: allow continue instead of if wrap in guard-for-in (fixes #&#8203;7567) (#&#8203;9796) (Michael Ficarra)
* af043eb Update: Add NewExpression support to comma-style (#&#8203;9591) (Frazer McLean)
* 4f898c7 Build: Fix JSDoc syntax errors (#&#8203;9813) (Matija Marohnić)
* 13bcf3c Fix: Removing curly quotes in no-eq-null report message (#&#8203;9852) (Kevin Partington)
* b96fb31 Docs: configuration hierarchy for CLIEngine options (fixes #&#8203;9526) (#&#8203;9855) (PiIsFour)
* 8ccbdda Docs: Clarify that -c configs merge with `.eslintrc.*` (fixes #&#8203;9535) (#&#8203;9847) (Kevin Partington)
* 978574f Docs: Fix examples for no-useless-escape (#&#8203;9853) (Toru Kobayashi)
* cd5681d Chore: Deactivate consistent-docs-url in internal rules folder (#&#8203;9815) (Kevin Partington)
* 2e87ddd Docs: Sync messageId examples' style with other examples (#&#8203;9816) (Kevin Partington)
* 1d61930 Update: use doctrine range information in valid-jsdoc (#&#8203;9831) (Teddy Katz)
* 133336e Update: fix indent behavior on template literal arguments (fixes #&#8203;9061) (#&#8203;9820) (Teddy Katz)
* ea1b15d Fix: avoid crashing on malformed configuration comments (fixes #&#8203;9373) (#&#8203;9819) (Teddy Katz)
* add1e70 Update: fix indent bug on comments in ternary expressions (fixes #&#8203;9729) (#&#8203;9818) (Teddy Katz)
* 6a5cd32 Fix: prefer-destructuring error with computed properties (fixes #&#8203;9784) (#&#8203;9817) (Teddy Katz)
* 601f851 Docs: Minor modification to code comments for clarity (#&#8203;9821) (rgovind92)
* b9da067 Docs: fix misleading info about RuleTester column numbers (#&#8203;9830) (Teddy Katz)
* 2cf4522 Update: Rename and deprecate object-property-newline option (#&#8203;9570) (Jonathan Pool)
* acde640 Docs: Add ES 2018 to Configuring ESLint (#&#8203;9829) (Kai Cataldo)
* ccfce15 Docs: Minor tweaks to working with rules page (#&#8203;9824) (Kevin Partington)
* 54b329a Docs: fix substitution of {{ name }} (#&#8203;9822) (Andres Kalle)

---

### [`v4.17.0`](https://github.com/eslint/eslint/releases/v4.17.0)

* 1da1ada Update: Add "multiline" type to padding-line-between-statements (#&#8203;8668) (Matthew Bennett)
* bb213dc Chore: Use messageIds in some of the core rules (#&#8203;9648) (Jed Fox)
* 1aa1970 Docs: remove outdated rule naming convention (#&#8203;9925) (Teddy Katz)
* 3afaff6 Docs: Add prefer-destructuring variable reassignment example (#&#8203;9873) (LePirlouit)
* d20f6b4 Fix: Typo in error message when running npm (#&#8203;9866) (Maciej Kasprzyk)
* 51ec6a7 Docs: Use GitHub Multiple PR/Issue templates (#&#8203;9911) (Kai Cataldo)
* dc80487 Update: space-unary-ops uses astUtils.canTokensBeAdjacent (fixes #&#8203;9907) (#&#8203;9906) (Kevin Partington)
* 084351b Docs: Fix the messageId example (fixes #&#8203;9889) (#&#8203;9892) (Jed Fox)
* 9cbb487 Docs: Mention the `globals` key in the no-undef docs (#&#8203;9867) (Dan Dascalescu)

---

### [`v4.18.0`](https://github.com/eslint/eslint/releases/v4.18.0)

* 70f22f3 Chore: Apply memoization to config creation within glob utils (#&#8203;9944) (Kenton Jacobsen)
* 0e4ae22 Update: fix indent bug with binary operators/ignoredNodes (fixes #&#8203;9882) (#&#8203;9951) (Teddy Katz)
* 47ac478 Update: add named imports and exports for object-curly-newline (#&#8203;9876) (Nicholas Chua)
* e8efdd0 Fix: support Rest/Spread Properties (fixes #&#8203;9885) (#&#8203;9943) (Toru Nagashima)
* f012b8c Fix: support Async iteration (fixes #&#8203;9891) (#&#8203;9957) (Toru Nagashima)
* 74fa253 Docs: Clarify no-mixed-operators options (fixes #&#8203;9962) (#&#8203;9964) (Ivan Hayes)
* 426868f Docs: clean up key-spacing docs (fixes #&#8203;9900) (#&#8203;9963) (Abid Uzair)
* 4a6f22e Update: support eslint-disable-* block comments (fixes #&#8203;8781) (#&#8203;9745) (Erin)
* 777283b Docs: Propose fix typo for function (#&#8203;9965) (John Eismeier)
* bf3d494 Docs: Fix typo in max-len ignorePattern example. (#&#8203;9956) (Tim Martin)
* d64fbb4 Docs: fix typo in prefer-destructuring.md example (#&#8203;9930) (Vse Mozhet Byt)
* f8d343f Chore: Fix default issue template (#&#8203;9946) (Kai Cataldo)

---

### [`v4.18.1`](https://github.com/eslint/eslint/releases/v4.18.1)

* f417506 Fix: ensure no-await-in-loop reports the correct node (fixes #&#8203;9992) (#&#8203;9993) (Teddy Katz)
* 3e99363 Docs: Fixed typo in key-spacing rule doc (#&#8203;9987) (Jaid)
* 7c2cd70 Docs: deprecate experimentalObjectRestSpread (#&#8203;9986) (Toru Nagashima)

---

### [`v4.18.2`](https://github.com/eslint/eslint/releases/v4.18.2)

* 6b71fd0 Fix: table@&#8203;4.0.2, because 4.0.3 needs "ajv": "^6.0.1" (#&#8203;10022) (Mathieu Seiler)
* 3c697de Chore: fix incorrect comment about linter.verify return value (#&#8203;10030) (Teddy Katz)
* 9df8653 Chore: refactor parser-loading out of linter.verify (#&#8203;10028) (Teddy Katz)
* f6901d0 Fix: remove catastrophic backtracking vulnerability (fixes #&#8203;10002) (#&#8203;10019) (Jamie Davis)
* e4f52ce Chore: Simplify dataflow in linter.verify (#&#8203;10020) (Teddy Katz)
* 33177cd Chore: make library files non-executable (#&#8203;10021) (Teddy Katz)
* 558ccba Chore: refactor directive comment processing (#&#8203;10007) (Teddy Katz)
* 18e15d9 Chore: avoid useless catch clauses that just rethrow errors (#&#8203;10010) (Teddy Katz)
* a1c3759 Chore: refactor populating configs with defaults in linter (#&#8203;10006) (Teddy Katz)
* aea07dc Fix: Make max-len ignoreStrings ignore JSXText (fixes #&#8203;9954) (#&#8203;9985) (Rachael Sim)

---

### [`v4.19.0`](https://github.com/eslint/eslint/releases/v4.19.0)

* 55a1593 Update: consecutive option for one-var (fixes #&#8203;4680) (#&#8203;9994) (薛定谔的猫)
* 8d3814e Fix: false positive about ES2018 RegExp enhancements (fixes #&#8203;9893) (#&#8203;10062) (Toru Nagashima)
* 935f4e4 Docs: Clarify default ignoring of node_modules (#&#8203;10092) (Matijs Brinkhuis)
* 72ed3db Docs: Wrap `Buffer()` in backticks in `no-buffer-constructor` rule description (#&#8203;10084) (Stephen Edgar)
* 3aded2f Docs: Fix lodash typos, make spacing consistent (#&#8203;10073) (Josh Smith)
* e33bb64 Chore: enable no-param-reassign on ESLint codebase (#&#8203;10065) (Teddy Katz)
* 66a1e9a Docs: fix possible typo (#&#8203;10060) (Vse Mozhet Byt)
* 2e68be6 Update: give a node at least the indentation of its parent (fixes #&#8203;9995) (#&#8203;10054) (Teddy Katz)
* 72ca5b3 Update: Correctly indent JSXText with trailing linebreaks (fixes #&#8203;9878) (#&#8203;10055) (Teddy Katz)
* 2a4c838 Docs: Update ECMAScript versions in FAQ (#&#8203;10047) (alberto)

---

### [`v4.19.1`](https://github.com/eslint/eslint/releases/v4.19.1)

* 3ff5d11 Fix: no-invalid-regexp not understand variable for flags (fixes #&#8203;10112) (#&#8203;10113) (薛定谔的猫)
* abc765c Fix: object-curly-newline minProperties w/default export (fixes #&#8203;10101) (#&#8203;10103) (Kevin Partington)
* 6f9e155 Docs: Update ambiguous for...in example for guard-for-in (#&#8203;10114) (CJ R)
* 0360cc2 Chore: Adding debug logs on successful plugin loads (#&#8203;10100) (Kevin Partington)
* a717c5d Chore: Adding log at beginning of unit tests in Makefile.js (#&#8203;10102) (Kevin Partington)

---

</details>


<details>
<summary>Commits</summary>

#### v4.15.0
-   [`6ab04b5`](https://github.com/eslint/eslint/commit/6ab04b553ec3ecb65ed3473b3f873b5a72af3675) New: Add context.report({ messageId }) (fixes #&#8203;6740) (#&#8203;9165)
-   [`2dfc3bd`](https://github.com/eslint/eslint/commit/2dfc3bdabacc59c9cdf24fb07961efda52d5dd02) Build: changelog update for 4.15.0
-   [`e14ceb0`](https://github.com/eslint/eslint/commit/e14ceb0451b0a18b4a78feb7d3521caf1c9d5747) 4.15.0
#### v4.16.0
-   [`54b329a`](https://github.com/eslint/eslint/commit/54b329ab0cb197baf8223515cbc17ca84ea88063) Docs: fix substitution of {{ name }} (#&#8203;9822)
-   [`ccfce15`](https://github.com/eslint/eslint/commit/ccfce15784fd2bedf8f19e89f009697f42eb4e0d) Docs: Minor tweaks to working with rules page (#&#8203;9824)
-   [`acde640`](https://github.com/eslint/eslint/commit/acde640da093bf7181de59b40eec41da2456ee3e) Docs: Add ES 2018 to Configuring ESLint (#&#8203;9829)
-   [`2cf4522`](https://github.com/eslint/eslint/commit/2cf452243351d2f9ff704aaf13a517cbde494ad4) Update: Rename and deprecate object-property-newline option (#&#8203;9570)
-   [`b9da067`](https://github.com/eslint/eslint/commit/b9da067deb7c15f6a908614001f755d39db43aa1) Docs: fix misleading info about RuleTester column numbers (#&#8203;9830)
-   [`601f851`](https://github.com/eslint/eslint/commit/601f8518ab2ba3fb6bcc00062b1fdca5f369c042) Docs: Minor modification to code comments for clarity (#&#8203;9821)
-   [`6a5cd32`](https://github.com/eslint/eslint/commit/6a5cd32e5a75b23558ad0282e080ffbb6affcad0) Fix: prefer-destructuring error with computed properties (fixes #&#8203;9784) (#&#8203;9817)
-   [`add1e70`](https://github.com/eslint/eslint/commit/add1e703a52b86662386f9b9b177b0fc86a33acc) Update: fix indent bug on comments in ternary expressions (fixes #&#8203;9729) (#&#8203;9818)
-   [`ea1b15d`](https://github.com/eslint/eslint/commit/ea1b15d3f996f10b63fcaec2efb44efdb7cda3a0) Fix: avoid crashing on malformed configuration comments (fixes #&#8203;9373) (#&#8203;9819)
-   [`133336e`](https://github.com/eslint/eslint/commit/133336e04edc59c7441fc0670b0b24dd15ded9b3) Update: fix indent behavior on template literal arguments (fixes #&#8203;9061) (#&#8203;9820)
-   [`1d61930`](https://github.com/eslint/eslint/commit/1d6193047b59a5e6b5cc296961b3cb79fbf07074) Update: use doctrine range information in valid-jsdoc (#&#8203;9831)
-   [`2e87ddd`](https://github.com/eslint/eslint/commit/2e87ddd43be4460b48d6c88fb51d3d138de47138) Docs: Sync messageId examples&#x27; style with other examples (#&#8203;9816)
-   [`cd5681d`](https://github.com/eslint/eslint/commit/cd5681dfb6e398f5fd869dfbe654cfa8ea32d34a) Chore: Deactivate consistent-docs-url in internal rules folder (#&#8203;9815)
-   [`978574f`](https://github.com/eslint/eslint/commit/978574f8b0d0e66d5f781e08bb874e0a9000278c) Docs: Fix examples for no-useless-escape (#&#8203;9853)
-   [`8ccbdda`](https://github.com/eslint/eslint/commit/8ccbdda6a4cf3ff9b2601f3278eebbb8a922c97e) Docs: Clarify that -c configs merge with `.eslintrc.*` (fixes #&#8203;9535) (#&#8203;9847)
-   [`b96fb31`](https://github.com/eslint/eslint/commit/b96fb318f8dd63937df74458b67f7bfb46ddeb66) Docs: configuration hierarchy for CLIEngine options (fixes #&#8203;9526) (#&#8203;9855)
-   [`13bcf3c`](https://github.com/eslint/eslint/commit/13bcf3ca531d699ee68567154e720377219773d0) Fix: Removing curly quotes in no-eq-null report message (#&#8203;9852)
-   [`4f898c7`](https://github.com/eslint/eslint/commit/4f898c74b4bdfea52c7cd9b8d2bf12c3c349eb88) Build: Fix JSDoc syntax errors (#&#8203;9813)
-   [`af043eb`](https://github.com/eslint/eslint/commit/af043eb6551d74d79710c6fbc0919bab203b9867) Update: Add NewExpression support to comma-style (#&#8203;9591)
-   [`e26a25f`](https://github.com/eslint/eslint/commit/e26a25fdeb191f48a44e3684ec5dd062a36306e7) Update: allow continue instead of if wrap in guard-for-in (fixes #&#8203;7567) (#&#8203;9796)
-   [`1a9ddee`](https://github.com/eslint/eslint/commit/1a9ddeed94b5e6f9d4dd45339faa540147b1b44c) Build: changelog update for 4.16.0
-   [`33ca1ea`](https://github.com/eslint/eslint/commit/33ca1ea67e41a05ff1283f6be36553db3904ec1f) 4.16.0
#### v4.17.0
-   [`9cbb487`](https://github.com/eslint/eslint/commit/9cbb487e8e84ff3268c05ab47b3b72c51b5f766e) Docs: Mention the `globals` key in the no-undef docs (#&#8203;9867)
-   [`084351b`](https://github.com/eslint/eslint/commit/084351bedb1001fc460e9acea4952b0b6139ec23) Docs: Fix the messageId example (fixes #&#8203;9889) (#&#8203;9892)
-   [`dc80487`](https://github.com/eslint/eslint/commit/dc804875fcac38dc4c89b7631007d534815c6078) Update: space-unary-ops uses astUtils.canTokensBeAdjacent (fixes #&#8203;9907) (#&#8203;9906)
-   [`51ec6a7`](https://github.com/eslint/eslint/commit/51ec6a71f2df0229577a568c4a5251eb8f02bf5a) Docs: Use GitHub Multiple PR/Issue templates (#&#8203;9911)
-   [`d20f6b4`](https://github.com/eslint/eslint/commit/d20f6b429839b253706e3e34f9b7a4a6c05f3fc2) Fix: Typo in error message when running npm (#&#8203;9866)
-   [`3afaff6`](https://github.com/eslint/eslint/commit/3afaff6039f4c5b3a8421b2746fb7bfa5d13ae9b) Docs: Add prefer-destructuring variable reassignment example (#&#8203;9873)
-   [`1aa1970`](https://github.com/eslint/eslint/commit/1aa1970632953dae3f3044386aaf043aea7ebf04) Docs: remove outdated rule naming convention (#&#8203;9925)
-   [`bb213dc`](https://github.com/eslint/eslint/commit/bb213dccfd0661fb82e8de42cbaa996c97722929) Chore: Use messageIds in some of the core rules (#&#8203;9648)
-   [`1da1ada`](https://github.com/eslint/eslint/commit/1da1ada2ce21960a450e7e97762cfca0c7dd7233) Update: Add &quot;multiline&quot; type to padding-line-between-statements (#&#8203;8668)
-   [`5ad3fb2`](https://github.com/eslint/eslint/commit/5ad3fb228a514823aa94b27ddd8943c0cac71690) Build: changelog update for 4.17.0
-   [`2af9446`](https://github.com/eslint/eslint/commit/2af94466fe8f87058fad4bd168958d2a7612a79d) 4.17.0
#### v4.18.0
-   [`f8d343f`](https://github.com/eslint/eslint/commit/f8d343fa29623051f97df0e5ea0139bd4258dfdb) Chore: Fix default issue template (#&#8203;9946)
-   [`d64fbb4`](https://github.com/eslint/eslint/commit/d64fbb41d344f70f155ee334c5eddac4c9d0861c) Docs: fix typo in prefer-destructuring.md example (#&#8203;9930)
-   [`bf3d494`](https://github.com/eslint/eslint/commit/bf3d4943aa583f042c315e640ef90018d016f2c2) Docs: Fix typo in max-len ignorePattern example. (#&#8203;9956)
-   [`777283b`](https://github.com/eslint/eslint/commit/777283b340ebaf4ca0a7ace6601d7d3b327cc8d4) Docs: Propose fix typo for function (#&#8203;9965)
-   [`4a6f22e`](https://github.com/eslint/eslint/commit/4a6f22e94d4ba1f1e5df748ab08c9f7d0b0140ec) Update: support eslint-disable-* block comments (fixes #&#8203;8781) (#&#8203;9745)
-   [`426868f`](https://github.com/eslint/eslint/commit/426868fdc70daa2996e35416190dc3835360da85) Docs: clean up key-spacing docs (fixes #&#8203;9900) (#&#8203;9963)
-   [`74fa253`](https://github.com/eslint/eslint/commit/74fa253555b60ea018e65655dd3866ed134c707c) Docs: Clarify no-mixed-operators options (fixes #&#8203;9962) (#&#8203;9964)
-   [`f012b8c`](https://github.com/eslint/eslint/commit/f012b8c7802e702a69ea8b3522cdc4c7842f038c) Fix: support Async iteration (fixes #&#8203;9891) (#&#8203;9957)
-   [`e8efdd0`](https://github.com/eslint/eslint/commit/e8efdd063f6dfaf32c9b4e237aff272721c01c1a) Fix: support Rest/Spread Properties (fixes #&#8203;9885) (#&#8203;9943)
-   [`47ac478`](https://github.com/eslint/eslint/commit/47ac478f3272fca771461e1cc6d4e91b1ecaaccc) Update: add named imports and exports for object-curly-newline (#&#8203;9876)
-   [`0e4ae22`](https://github.com/eslint/eslint/commit/0e4ae22d4adebd1cb603ac9cb55daf70c9b921d0) Update: fix indent bug with binary operators/ignoredNodes (fixes #&#8203;9882) (#&#8203;9951)
-   [`70f22f3`](https://github.com/eslint/eslint/commit/70f22f3f545402811068cee1fae5035be3dc4600) Chore: Apply memoization to config creation within glob utils (#&#8203;9944)
-   [`89d55ca`](https://github.com/eslint/eslint/commit/89d55ca21d2d6b36b629dc78bef3c3dcbadf0296) Build: changelog update for 4.18.0
-   [`883a2a2`](https://github.com/eslint/eslint/commit/883a2a2eee1adcc832d43ef77140ff7e2736e676) 4.18.0
#### v4.18.1
-   [`7c2cd70`](https://github.com/eslint/eslint/commit/7c2cd70c95f6795169d72577754452716b440851) Docs: deprecate experimentalObjectRestSpread (#&#8203;9986)
-   [`3e99363`](https://github.com/eslint/eslint/commit/3e9936371df8235c1dfe5f7d58fad4632e45e975) Docs: Fixed typo in key-spacing rule doc (#&#8203;9987)
-   [`f417506`](https://github.com/eslint/eslint/commit/f417506198d2ab8deca1e6127c164cef882d356f) Fix: ensure no-await-in-loop reports the correct node (fixes #&#8203;9992) (#&#8203;9993)
-   [`537b5c3`](https://github.com/eslint/eslint/commit/537b5c32f8ad49063375a4961f9eb54c68de8963) Build: changelog update for 4.18.1
-   [`8c237d8`](https://github.com/eslint/eslint/commit/8c237d8be368798acea876adedd3533a99e30368) 4.18.1
#### v4.18.2
-   [`aea07dc`](https://github.com/eslint/eslint/commit/aea07dc88689ff0d6fea27e4099ce7f1a42ff90a) Fix: Make max-len ignoreStrings ignore JSXText (fixes #&#8203;9954) (#&#8203;9985)
-   [`a1c3759`](https://github.com/eslint/eslint/commit/a1c3759adfd087c8b5c3c892b92885b7dded4224) Chore: refactor populating configs with defaults in linter (#&#8203;10006)
-   [`18e15d9`](https://github.com/eslint/eslint/commit/18e15d978c17503f7ca352333a47069afcb70a1c) Chore: avoid useless catch clauses that just rethrow errors (#&#8203;10010)
-   [`558ccba`](https://github.com/eslint/eslint/commit/558ccba0fc8cafd969c7f18ff09be7fc0670536f) Chore: refactor directive comment processing (#&#8203;10007)
-   [`33177cd`](https://github.com/eslint/eslint/commit/33177cd863e37897fd1c7e98f2f69ba31028453b) Chore: make library files non-executable (#&#8203;10021)
-   [`e4f52ce`](https://github.com/eslint/eslint/commit/e4f52ce6a6b6149e21b1d1a2f3f5f71d58d7106a) Chore: Simplify dataflow in linter.verify (#&#8203;10020)
-   [`f6901d0`](https://github.com/eslint/eslint/commit/f6901d0bcf6c918ac4e5c6c7c4bddeb2cb715c09) Fix: remove catastrophic backtracking vulnerability (fixes #&#8203;10002) (#&#8203;10019)
-   [`9df8653`](https://github.com/eslint/eslint/commit/9df865326616b9865ab186c9769e95bc0bf98a20) Chore: refactor parser-loading out of linter.verify (#&#8203;10028)
-   [`3c697de`](https://github.com/eslint/eslint/commit/3c697de6182b19d49b910a33b1bc6b0a0e2569b3) Chore: fix incorrect comment about linter.verify return value (#&#8203;10030)
-   [`6b71fd0`](https://github.com/eslint/eslint/commit/6b71fd0bcbf9cc00ed4076587f5692b72f6e9aa5) Fix: table@&#8203;4.0.2, because 4.0.3 needs &quot;ajv&quot;: &quot;^6.0.1&quot; (#&#8203;10022)
-   [`817b84b`](https://github.com/eslint/eslint/commit/817b84bf523dee12884ed37c9c86328e9fb5c532) Build: changelog update for 4.18.2
-   [`22ff6f3`](https://github.com/eslint/eslint/commit/22ff6f3ab122f61c10fa51f9b1082f2e6f302938) 4.18.2
#### v4.19.0
-   [`2a4c838`](https://github.com/eslint/eslint/commit/2a4c838c7d9d13050028b23925f4691d215d8337) Docs: Update ECMAScript versions in FAQ (#&#8203;10047)
-   [`72ca5b3`](https://github.com/eslint/eslint/commit/72ca5b35b843cc376a66632e07c307f923063701) Update: Correctly indent JSXText with trailing linebreaks (fixes #&#8203;9878) (#&#8203;10055)
-   [`2e68be6`](https://github.com/eslint/eslint/commit/2e68be643178eeb86f2b9f66bc1670b624cb09f2) Update: give a node at least the indentation of its parent (fixes #&#8203;9995) (#&#8203;10054)
-   [`66a1e9a`](https://github.com/eslint/eslint/commit/66a1e9aa85c37c1d4430ad633d8354930c818796) Docs: fix possible typo (#&#8203;10060)
-   [`e33bb64`](https://github.com/eslint/eslint/commit/e33bb64601b1dffe1b8bc8b2a5142121c8b56523) Chore: enable no-param-reassign on ESLint codebase (#&#8203;10065)
-   [`3aded2f`](https://github.com/eslint/eslint/commit/3aded2f984a6bc972a3f2198fddcf4a323d7a201) Docs: Fix lodash typos, make spacing consistent (#&#8203;10073)
-   [`72ed3db`](https://github.com/eslint/eslint/commit/72ed3dbcdda8ec1387e75676c3166fec71337a69) Docs: Wrap `Buffer()` in backticks in `no-buffer-constructor` rule description (#&#8203;10084)
-   [`935f4e4`](https://github.com/eslint/eslint/commit/935f4e460d83c39f107118c4c4dbb7f6b58684b1) Docs: Clarify default ignoring of node_modules (#&#8203;10092)
-   [`8d3814e`](https://github.com/eslint/eslint/commit/8d3814e4ae823e58f40539047bb35bcaf5c76660) Fix: false positive about ES2018 RegExp enhancements (fixes #&#8203;9893) (#&#8203;10062)
-   [`55a1593`](https://github.com/eslint/eslint/commit/55a15936346def8ddc0c5023431df20bec798fb2) Update: consecutive option for one-var (fixes #&#8203;4680) (#&#8203;9994)
-   [`16fc59e`](https://github.com/eslint/eslint/commit/16fc59e95140aeb7d7cda732aca7921a12b046c1) Build: changelog update for 4.19.0
-   [`4f595e8`](https://github.com/eslint/eslint/commit/4f595e8a7cc1fefae866d2cf0e758515d6098e3c) 4.19.0
#### v4.19.1
-   [`a717c5d`](https://github.com/eslint/eslint/commit/a717c5db7575c0ba677f1fd1e909cba08818bfae) Chore: Adding log at beginning of unit tests in Makefile.js (#&#8203;10102)
-   [`0360cc2`](https://github.com/eslint/eslint/commit/0360cc25c86619d30e37e25d4ce9a78309591c18) Chore: Adding debug logs on successful plugin loads (#&#8203;10100)
-   [`6f9e155`](https://github.com/eslint/eslint/commit/6f9e15514e7a6b880b7c735ac9e8b43aed3cc67e) Docs: Update ambiguous for...in example for guard-for-in (#&#8203;10114)
-   [`abc765c`](https://github.com/eslint/eslint/commit/abc765c1bc6b546db82cb5cd038b66a3aa68b315) Fix: object-curly-newline minProperties w/default export (fixes #&#8203;10101) (#&#8203;10103)
-   [`3ff5d11`](https://github.com/eslint/eslint/commit/3ff5d11fe2ed601d4e0226bde50c06fe7c7f16ac) Fix: no-invalid-regexp not understand variable for flags (fixes #&#8203;10112) (#&#8203;10113)
-   [`b446650`](https://github.com/eslint/eslint/commit/b446650083012a152ec55dd19c20f2ce951eb30a) Build: changelog update for 4.19.1
-   [`f1f1bdf`](https://github.com/eslint/eslint/commit/f1f1bdfffe0c2675e42cb6ad58145d40a6870135) 4.19.1

</details>